### PR TITLE
fix preprocessor logic with HAVE_STAT

### DIFF
--- a/src/lib/crypto/ares_openssl.c
+++ b/src/lib/crypto/ares_openssl.c
@@ -174,11 +174,8 @@ static ares_bool_t file_exists(const char *path, ares_bool_t is_directory)
   if (stat(filename, &st) != 0) {
     return ARES_FALSE;
   }
-#    elif defined(_WIN32)
-  struct _stat st;
-  if (_stat(filename, &st) != 0) {
-    return ARES_FALSE;
-  }
+#    else
+#      error "Need stat() function for crypto subsystem with OpenSSL."
 #    endif
   if (is_directory) {
     if (st.st_mode & S_IFDIR) {

--- a/src/lib/crypto/ares_openssl.c
+++ b/src/lib/crypto/ares_openssl.c
@@ -171,7 +171,7 @@ static ares_bool_t file_exists(const char *path, ares_bool_t is_directory)
 {
 #    ifdef HAVE_STAT
   struct stat st;
-  if (stat(filename, &st) != 0) {
+  if (stat(path, &st) != 0) {
     return ARES_FALSE;
   }
 #    else


### PR DESCRIPTION
The _WIN32 check is inside a preprocessor branch that has already
checked that _WIN32 is not defined.

On the other hand, if HAVE_STAT is not available, then the function
does not have an alternative method to check that a file exists. The
not-apple-not-windows branch should have stat() available, so this is
a very unlikely situation.
